### PR TITLE
Switch to add_documents_in_batches

### DIFF
--- a/meilisync/meili.py
+++ b/meilisync/meili.py
@@ -26,8 +26,9 @@ class Meili:
 
     async def add_full_data(self, index: str, pk: str, data: list):
         batch_size = 1000
-        for i in range(0, len(data), batch_size):
-            await self.client.index(index).add_documents(data[i : i + batch_size], primary_key=pk)
+        await self.client.index(index).add_documents_in_batches(
+            data, batch_size=batch_size, primary_key=pk
+        )
 
     async def handle_event(self, event: Event):
         if self.debug:


### PR DESCRIPTION
`meilisearch_python_async` has an `add_documents_in_batches` method that takes advantage of Python's `asyncio.gather` functionality and should improve performance with adding batches. This PR switches from `add_documents` to `add_documents_in_batches` to take advantage of that. 