### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Build artifacts
+build/
+dist/
+
+# Git/GitHub
+.git/
+.github/
+.gitignore
+
+# Python specific files
+**/__pycache__
+**/.mypy_cache/
+**/.pytest_cache/
+**/.ruff_cache/
+**/*.py[cod]
+**/*.egg
+tests/
+
+# C extensions
+*.so
+
+# pyenv
+**/.python-version
+
+# Virtual Environments
+**/.env
+**/.venv
+**/env/
+**/venv/
+
+# Editors
+**/.vscode/
+**/.idea/
+
+# Docker
+docker-compose.yml
+docker-compose.yaml
+Dockerfile
+
+# Project files
+CHANGELOG.md


### PR DESCRIPTION
Adding a `.dockerignore` file results in a 32% decrease in the build image size (464mb to 316mb)