### PR TITLE
Add option to set meilisearch setting from envoronment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Source database configuration, currently only support MySQL and PostgreSQL and M
 
 MeiliSearch configuration.
 
-- `api_url`: the MeiliSearch API URL.
-- `api_key`: the MeiliSearch API key.
+- `api_url`: the MeiliSearch API URL. This can be set from the `MEILI_HTTP_ADDR` environment variable
+- `api_key`: the MeiliSearch API key. This can be set with the `MEILI_MASTER_KEY` environment varable
 
 ### sync
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Source database configuration, currently only support MySQL and PostgreSQL and M
 
 MeiliSearch configuration.
 
-- `api_url`: the MeiliSearch API URL. This can be set from the `MEILI_HTTP_ADDR` environment variable
-- `api_key`: the MeiliSearch API key. This can be set with the `MEILI_MASTER_KEY` environment varable
+- `api_url`: the MeiliSearch API URL. This can be set from the `MEILI_HTTP_ADDR` environment variable.
+- `api_key`: the MeiliSearch API key. This can be set with the `MEILI_MASTER_KEY` environment varable.
 
 ### sync
 

--- a/meilisync/settings.py
+++ b/meilisync/settings.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, BaseSettings, Extra
+from pydantic import BaseModel, BaseSettings, Extra, Field
 
 from meilisync.enums import ProgressType, SourceType
 from meilisync.plugin import load_plugin
@@ -16,9 +16,9 @@ class Source(BaseModel):
         extra = Extra.allow
 
 
-class MeiliSearch(BaseModel):
-    api_url: str
-    api_key: Optional[str]
+class MeiliSearch(BaseSettings):
+    api_url: str = Field(..., env="MEILI_HTTP_ADDR")
+    api_key: Optional[str] = Field(None, env="MEILI_MASTER_KEY")
 
 
 class BasePlugin(BaseModel):


### PR DESCRIPTION
Meilisearch has the option to set the api url and master key through [environment variables](https://docs.meilisearch.com/learn/configuration/instance_options.html#environment-variables). I have added the option for the `settings` here to use these same environment vairables to set the `api_url` and `api_key`. This way, especially with the `api_key`, it doesn't need to be stored as plain text in the `config.yml` or passed as plain text into the settings.