### PR TITLE
Add support to datetime fields

### DIFF
--- a/meilisync/schemas.py
+++ b/meilisync/schemas.py
@@ -1,3 +1,5 @@
+import datetime
+
 from typing import Optional
 
 from pydantic import BaseModel
@@ -15,10 +17,14 @@ class Event(ProgressEvent):
     data: dict
 
     def mapping_data(self, fields_mapping: Optional[dict] = None):
-        if not fields_mapping:
-            return self.data
         data = {}
         for k, v in self.data.items():
-            if k in fields_mapping:
-                data[fields_mapping[k] or k] = v
+            if isinstance(v, datetime.datetime):
+                v = int(v.timestamp())
+
+            if (fields_mapping is not None) and k in fields_mapping:
+                data[fields_mapping[k]] = v
+            else:
+                data[k] = v
+
         return data or self.data

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -14,17 +14,18 @@ async def test_sync():
         password="123456",
         port=3306,
         database="test",
-    )
+    ) 
     async with conn.cursor() as cur:
         await cur.execute("DROP TABLE IF EXISTS test")
-        await cur.execute("CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT)")
-        await cur.execute("INSERT INTO test (id, age) VALUES (%s, %s)", (1, 18))
+        await cur.execute("CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT, birthday timestamp NOT NULL)")
+        await cur.execute("INSERT INTO test (id, age, birthday) VALUES (%s, %s, %s)", (1, 46, '1977-01-27 22:00:53'))
         await conn.commit()
     await asyncio.sleep(2)
     ret = await index.get_documents()
     assert ret.results == [
         {
             "id": 1,
-            "age": 18,
+            "age": 46,
+            "birthday": 223250453
         }
     ]

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -18,13 +18,13 @@ async def test_sync():
     async with conn.cursor() as cur:
         await cur.execute("DROP TABLE IF EXISTS test")
         await cur.execute(
-            "CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT, birthday timestamp NOT NULL)"
+            "CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT, time timestamp NOT NULL)"
         )
         await cur.execute(
-            "INSERT INTO test (id, age, birthday) VALUES (%s, %s, %s)",
+            "INSERT INTO test (id, age, time) VALUES (%s, %s, %s)",
             (1, 46, "1977-01-27 22:00:53"),
         )
         await conn.commit()
     await asyncio.sleep(2)
     ret = await index.get_documents()
-    assert ret.results == [{"id": 1, "age": 46, "birthday": 223250453}]
+    assert ret.results == [{"id": 1, "age": 46, "time": 223250453}]

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -14,18 +14,17 @@ async def test_sync():
         password="123456",
         port=3306,
         database="test",
-    ) 
+    )
     async with conn.cursor() as cur:
         await cur.execute("DROP TABLE IF EXISTS test")
-        await cur.execute("CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT, birthday timestamp NOT NULL)")
-        await cur.execute("INSERT INTO test (id, age, birthday) VALUES (%s, %s, %s)", (1, 46, '1977-01-27 22:00:53'))
+        await cur.execute(
+            "CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, age INT, birthday timestamp NOT NULL)"
+        )
+        await cur.execute(
+            "INSERT INTO test (id, age, birthday) VALUES (%s, %s, %s)",
+            (1, 46, "1977-01-27 22:00:53"),
+        )
         await conn.commit()
     await asyncio.sleep(2)
     ret = await index.get_documents()
-    assert ret.results == [
-        {
-            "id": 1,
-            "age": 46,
-            "birthday": 223250453
-        }
-    ]
+    assert ret.results == [{"id": 1, "age": 46, "birthday": 223250453}]


### PR DESCRIPTION
When python identifies a valid DateTime field, it will be converted to a timestamp before being sent to meilisearch.

According to: https://www.meilisearch.com/docs/learn/advanced/working_with_dates

Fixes #8 