### PR TITLE
Fix: Delete Failures in Postgres Handled

### DIFF
--- a/meilisync/source/postgres.py
+++ b/meilisync/source/postgres.py
@@ -81,12 +81,23 @@ class Postgres(Source):
                 return
             columnnames = change.get("columnnames")
             columnvalues = change.get("columnvalues")
-            values = dict(zip(columnnames, columnvalues))
+            
             if kind == "update":
+                                values = (
+                    dict(zip(columnnames, columnvalues))
+                    if columnvalues
+                    else {
+                        change["oldkeys"]["keynames"][0]: change["oldkeys"][
+                            "keyvalues"
+                        ][0]
+                    }
+                )
                 event_type = EventType.update
             elif kind == "delete":
+                values = dict(zip(columnnames, columnvalues))
                 event_type = EventType.delete
             elif kind == "insert":
+                values = dict(zip(columnnames, columnvalues))
                 event_type = EventType.create
             else:
                 return

--- a/meilisync/source/postgres.py
+++ b/meilisync/source/postgres.py
@@ -83,7 +83,10 @@ class Postgres(Source):
             columnvalues = change.get("columnvalues")
             
             if kind == "update":
-                                values = (
+                values = dict(zip(columnnames, columnvalues))
+                event_type = EventType.update
+            elif kind == "delete":
+                values = (
                     dict(zip(columnnames, columnvalues))
                     if columnvalues
                     else {
@@ -92,9 +95,6 @@ class Postgres(Source):
                         ][0]
                     }
                 )
-                event_type = EventType.update
-            elif kind == "delete":
-                values = dict(zip(columnnames, columnvalues))
                 event_type = EventType.delete
             elif kind == "insert":
                 values = dict(zip(columnnames, columnvalues))


### PR DESCRIPTION
This pull request fixes an issue in our Postgres consumer's handling of delete events, which was reported in [issue #22](https://github.com/long2ice/meilisync/issues/22).

In delete events, Postgres does not provide `columnnames` or `columnvalues` but instead only sends the `id` of the deleted row along with all column values. Our consumer now correctly captures the `id` from `oldkeys` to construct the necessary data for delete events.

Changes:
- Updated delete event handling to fetch the `id` from `change["oldkeys"]["keynames"][0]` and `change["oldkeys"]["keyvalues"][0]`.

Here's an example of a delete event change object that this fix accommodates:
```json
{
  "kind": "delete",
  "schema": "public",
  "table": "products",
  "oldkeys": {
    "keynames": ["id"],
    "keytypes": ["integer"],
    "keyvalues": [25]
  }
}

