### PR TITLE
Support env variables in config.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ sentry:
   environment: "production"
 ```
 
+It is possible to use environment variables inside the configuration file, using the format `${VARIABLE_NAME}`, for example `user: ${DB_USER}`.
+
 ### debug (optional)
 
 Enable debug mode, default is `false`, if you want to see more logs, you can set it to `true`.

--- a/meilisync/main.py
+++ b/meilisync/main.py
@@ -11,6 +11,7 @@ from meilisync.meili import Meili
 from meilisync.schemas import Event
 from meilisync.settings import Settings
 from meilisync.version import __VERSION__
+from meilisync.yaml_parser import parse_yaml
 
 app = typer.Typer()
 
@@ -29,9 +30,7 @@ def callback(
         if context.invoked_subcommand == "version":
             return
         context.ensure_object(dict)
-        with open(config_file) as f:
-            config = f.read()
-        settings = Settings.model_validate(yaml.safe_load(config))
+        settings = Settings.model_validate(parse_yaml(config_file))
         if settings.debug:
             logger.debug(settings)
         if settings.sentry:

--- a/meilisync/yaml_parser.py
+++ b/meilisync/yaml_parser.py
@@ -1,0 +1,25 @@
+import os
+import re
+
+import yaml
+
+
+class EnvVarLoader(yaml.SafeLoader):
+    pass
+
+
+def path_constructor(loader, node):
+    return os.path.expandvars(node.value)
+
+
+path_matcher = re.compile(r".*\$\{([^}^{]+)\}.*")
+# apply path_constructor to YAML nodes that match the ${...} expression pattern
+EnvVarLoader.add_implicit_resolver("!path", path_matcher, None)
+EnvVarLoader.add_constructor("!path", path_constructor)
+
+
+def parse_yaml(config_file: str) -> dict:
+    with open(config_file) as f:
+        config = yaml.load(f, Loader=EnvVarLoader)
+
+    return config


### PR DESCRIPTION
With these changes, it would be possible to parse a YAML file with env variables with the format `${VARIABLE_NAME}`, like the following one:
```yaml
progress:
  type: file
meilisearch:
  api_url: ${MEILISEARCH_API_URL}
  api_key: ${MEILISEARCH_API_KEY}
source:
  type: mysql
  host: ${DB_HOST}
  port: ${DB_PORT}
  database: ${DB_DATABASE}
  user: ${DB_USER}
  password: ${DB_PASSWORD}
sync:
  - table: ${TABLE_NAME}
    index: ${INDEX_NAME}
    pk: id
```