### PR TITLE
Gracefully handle optional dependencies

### DIFF
--- a/meilisync/discover.py
+++ b/meilisync/discover.py
@@ -13,7 +13,11 @@ from meilisync.source import Source
 def _discover(module: ModuleType, t: Type):
     ret = {}
     for m in pkgutil.iter_modules(module.__path__):
-        mod = importlib.import_module(f"{module.__name__}.{m.name}")
+        try:
+            mod = importlib.import_module(f"{module.__name__}.{m.name}")
+        except ModuleNotFoundError:
+            # Enables optional dependencies of sources and progress.
+            continue
         for _, member in inspect.getmembers(mod, inspect.isclass):
             if issubclass(member, t) and member is not t:
                 ret[member.type] = member


### PR DESCRIPTION
If you have not installed via `meilisync[all]`, `importlib.import_module` will throw a `ModuleNotFoundError` for any missing dependencies.
This kind of defeats the point of supporting `meilisync[postgres]` etc.

If the exception is caught it will support the use of optional dependencies.

example error:
```python
  File ".venv/lib/python3.12/site-packages/meilisync/discover.py", line 23, in <module>
    _sources = _discover(source, Source)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/meilisync/discover.py", line 16, in _discover
    mod = importlib.import_module(f"{module.__name__}.{m.name}")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.12/site-packages/meilisync/source/mongo.py", line 3, in <module>
    import motor.motor_asyncio
ModuleNotFoundError: No module named 'motor'
```