### PR TITLE
MySQL support for bulk inserts, deletes by reading multiple event rows

### DIFF
--- a/meilisync/event.py
+++ b/meilisync/event.py
@@ -10,7 +10,8 @@ class EventCollection:
     def add_event(self, sync: Sync, event: Event):
         pk = event.data[sync.pk]
         self._events.setdefault(sync, {})
-        self._events[sync][pk] = event
+        self._events[sync].setdefault(pk, [])
+        self._events[sync][pk].append(event)
 
     @property
     def size(self):
@@ -21,16 +22,17 @@ class EventCollection:
         updated_events = {}
         created_events = {}
         deleted_events = {}
-        for sync, events in self._events.items():
+        for sync, pk_events_dict in self._events.items():
             updated_events[sync] = []
             created_events[sync] = []
             deleted_events[sync] = []
-            for event in events.values():
-                if event.type == EventType.create:
-                    created_events[sync].append(event)
-                elif event.type == EventType.update:
-                    updated_events[sync].append(event)
-                elif event.type == EventType.delete:
-                    deleted_events[sync].append(event)
+            for events in pk_events_dict.values():
+                for event in events:
+                    if event.type == EventType.create:
+                        created_events[sync].append(event)
+                    elif event.type == EventType.update:
+                        updated_events[sync].append(event)
+                    elif event.type == EventType.delete:
+                        deleted_events[sync].append(event)
         self._events = {}
         return created_events, updated_events, deleted_events

--- a/meilisync/source/mysql.py
+++ b/meilisync/source/mysql.py
@@ -118,15 +118,13 @@ class MySQL(Source):
                         continue
                     self.progress["master_log_file"] = self.stream._master_log_file
                     self.progress["master_log_position"] = self.stream._master_log_position
-                    yield from (
-                        Event(
+                    for data in data_list:
+                        yield Event(
                             type=event_type,
                             table=event.table,
                             data=data,
                             progress=self.progress,
                         )
-                        for data in data_list
-                    )
             except OperationalError as e:
                 logger.exception(f"Binlog stream error: {e}, sleep 10s and retry...")
                 await asyncio.sleep(10)

--- a/meilisync/source/mysql.py
+++ b/meilisync/source/mysql.py
@@ -107,22 +107,25 @@ class MySQL(Source):
                 async for event in self.stream:
                     if isinstance(event, WriteRowsEvent):
                         event_type = EventType.create
-                        data = event.rows[0]["values"]
+                        data_list = [row["values"] for row in event.rows]
                     elif isinstance(event, UpdateRowsEvent):
                         event_type = EventType.update
-                        data = event.rows[0]["after_values"]
+                        data_list = [row["after_values"] for row in event.rows]
                     elif isinstance(event, DeleteRowsEvent):
                         event_type = EventType.delete
-                        data = event.rows[0]["values"]
+                        data_list = [row["values"] for row in event.rows]
                     else:
                         continue
                     self.progress["master_log_file"] = self.stream._master_log_file
                     self.progress["master_log_position"] = self.stream._master_log_position
-                    yield Event(
-                        type=event_type,
-                        table=event.table,
-                        data=data,
-                        progress=self.progress,
+                    yield from (
+                        Event(
+                            type=event_type,
+                            table=event.table,
+                            data=data,
+                            progress=self.progress,
+                        )
+                        for data in data_list
                     )
             except OperationalError as e:
                 logger.exception(f"Binlog stream error: {e}, sleep 10s and retry...")


### PR DESCRIPTION
# MySQL support for bulk inserts, deletes by reading multiple event

## Description

Refactor binlog event processing to support bulk operations.

Instead of assuming the ifrst index of event.rows contains the full pyload of the binlog event, we iterate through the full event,  picking up additional inserts, deletes.

## Testing

Tested against an a hosted MySQL instance. Flows from our backend that were leading to meilisearch being out of sync are now working as expected. 

## Related Issue

https://github.com/long2ice/meilisync/issues/93
