### PR TITLE
Postgres: Use a server side cursor for `get_full_data`

### DIFF
--- a/meilisync/source/postgres.py
+++ b/meilisync/source/postgres.py
@@ -71,9 +71,7 @@ class Postgres(Source):
             fields = "*"
 
         def execute():
-            cur.execute(
-                f"SELECT {fields} FROM {sync.table}"
-            )
+            cur.execute(f"SELECT {fields} FROM {sync.table}")
 
         def fetch():
             return cur.fetchmany(size)


### PR DESCRIPTION
Fixes performance issue for `get_full_data`: https://github.com/long2ice/meilisync/issues/105