### PR TITLE
Dev: Tests: Make tests runnable through docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,6 @@ dist/
 **/.ruff_cache/
 **/*.py[cod]
 **/*.egg
-tests/
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 .idea
 *.json
 .DS_Store
+
+# Docker
+meili_data/

--- a/README.md
+++ b/README.md
@@ -231,8 +231,20 @@ Setup
 
 Then to run the tests
 
+Mongo
 ```
-docker exec -it meilisync-localdev-meilisync-1 poetry run pytest
+docker exec -it meilisync-localdev-meilisync-1 meilisync --config tests/config/mongo.yml start
+docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_mongo.py
+```
+MySQL
+```
+docker exec -it meilisync-localdev-meilisync-1 meilisync --config tests/config/mysql.yml start
+docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_mysql.py
+```
+Postgres
+```
+docker exec -it meilisync-localdev-meilisync-1 meilisync --config tests/config/postgres.yml start
+docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_mysql.py
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_mysq
 Postgres
 ```
 docker exec -it meilisync-localdev-meilisync-1 meilisync --config tests/config/postgres.yml start
-docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_mysql.py
+docker exec -it meilisync-localdev-meilisync-1 poetry run pytest tests/test_postgres.py
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ Sentry configuration.
 - `dsn`: the sentry dsn.
 - `environment`: the sentry environment, default is `production`.
 
+
+## Contributing
+
+### Running Tests
+
+Setup
+1. get the docker services running initially
+  `docker compose -f ./compose.dev.yml up --build -d`
+1. edit the `test/config/*.yml` files, adding the "Default Admin API Key" api key from `meili_data/api_keys.json` to the `meilisearch.api_key` field
+2. `docker compose up --build -d`
+
+Then to run the tests
+
+```
+docker exec -it meilisync-localdev-meilisync-1 poetry run pytest
+```
+
 ## License
 
 This project is licensed under the

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,58 @@
+name: meilisync-localdev
+services:
+  meilisync:
+    platform: linux/x86_64
+    build: .
+    restart: always
+    command: ["meilisync", "start"]
+    depends_on:
+      - meilisearch
+      - db-mongo
+
+  db-postgres:
+    build: tests/docker/postgres
+    container_name: postgres_db
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 123456
+      POSTGRES_DB: test
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    command: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]
+  
+  db-mysql:
+    image: mysql:9
+    container_name: mysql_db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 123456
+      MYSQL_DATABASE: test
+    ports:
+      - "3306:3306"
+
+  db-mongo:
+    build: tests/docker/mongo
+    container_name: mongo_db
+    restart: always
+    environment:
+      MONGO_INITDB_DATABASE: test
+    ports:
+      - "27017:27017"  
+
+  meilisearch:
+    build: tests/docker/meilisearch
+    container_name: my-meilisearch
+    environment:
+      - MEILI_MASTER_KEY=this-is-just-a-test-key-for-local-dev
+      # dev convenience to copy api keys
+      - MEILI_API_KEYS_FILE=/meili_data/api_keys.json
+    volumes:
+      - ./meili_data:/meili_data
+    ports:
+      - "7700:7700"
+
+volumes:
+  postgres_data:

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -4,10 +4,12 @@ services:
     platform: linux/x86_64
     build: .
     restart: always
-    command: ["meilisync", "start"]
+    command: ["sleep", "infinity"]
     depends_on:
       - meilisearch
       - db-mongo
+      - db-postgres
+      - db-mysql
 
   db-postgres:
     build: tests/docker/postgres

--- a/meilisync/source/mysql.py
+++ b/meilisync/source/mysql.py
@@ -32,8 +32,11 @@ class MySQL(Source):
         self.server_id = int(server_id)
         self.database = kwargs.get("database")
 
+    async def get_connection(self):
+        return await asyncmy.connect(**self.kwargs)
+
     async def get_full_data(self, sync: Sync, size: int):
-        conn = await asyncmy.connect(**self.kwargs)
+        conn = await self.get_connection()
         if sync.fields:
             fields = ", ".join(f"{field} as {sync.fields[field] or field}" for field in sync.fields)
         else:

--- a/tests/config/mongo.yml
+++ b/tests/config/mongo.yml
@@ -4,15 +4,14 @@ progress:
   path: mongo.json
 source:
   type: mongo
-  host: localhost
+  host: db-mongo
   port: 27017
-  username: root
-  password: root
   database: test
   replicaSet: rs0
   directConnection: true
 meilisearch:
-  api_url: http://localhost:7700
+  api_url: http://meilisearch:7700
+  api_key: # admin api key goes here
 sync:
   - table: test
     index: mongo

--- a/tests/config/mysql.yml
+++ b/tests/config/mysql.yml
@@ -4,13 +4,14 @@ progress:
   path: mysql.json
 source:
   type: mysql
-  host: localhost
+  host: db-mysql
   port: 3306
   user: root
   password: "123456"
   database: test
 meilisearch:
-  api_url: http://localhost:7700
+  api_url: http://meilisearch:7700
+  api_key: # admin api key goes here
 sync:
   - table: test
     index: mysql

--- a/tests/config/postgres.yml
+++ b/tests/config/postgres.yml
@@ -4,14 +4,15 @@ progress:
   path: postgres.json
 source:
   type: postgres
-  host: localhost
+  host: db-postgres
   port: 5432
   user: postgres
-  password: postgres
+  password: "123456"
   database: test
 meilisearch:
-  api_url: http://localhost:7700
+  api_url: http://meilisearch:7700
+  api_key: # admin api key goes here
 sync:
   - table: test
     index: postgres
-    full: false
+    full: true

--- a/tests/docker/meilisearch/Dockerfile
+++ b/tests/docker/meilisearch/Dockerfile
@@ -1,0 +1,10 @@
+FROM getmeili/meilisearch:v1.10@sha256:db5c90b14b406d4cee34c5b6dcd4cffe66ef8766534b079b7db97fe145d01a21
+
+# Install jq for easier parsing of api keys
+RUN apk update && apk add --no-cache jq
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENV MEILI_API_KEYS_FILE=$MEILI_API_KEYS_FILE
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tests/docker/meilisearch/entrypoint.sh
+++ b/tests/docker/meilisearch/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Waits for meilisearch to start, then adds the api keys to disk for easier copying
+set -e
+
+echo "Starting MeiliSearch..."
+meilisearch --master-key "${MEILI_MASTER_KEY}" &
+MEILI_PID=$!
+
+echo "Waiting for MeiliSearch to be healthy..."
+while true; do
+  if curl -s http://0.0.0.0:7700/health | grep -q '"status":"available"'; then
+    break
+  fi
+  sleep 1
+done
+
+echo "MeiliSearch is healthy."
+
+
+if [ ! -f "$MEILI_API_KEYS_FILE" ]; then
+  echo "Key file not found. Retrieving default search API key..."
+  sleep 2
+  keys=$(curl -s -H "Authorization: Bearer ${MEILI_MASTER_KEY}" http://0.0.0.0:7700/keys)
+  pretty_json=$(echo "$keys" | jq .)
+  
+  if [ -n "$pretty_json" ] && [ "$pretty_json" != "null" ]; then
+    echo "$pretty_json" > "$MEILI_API_KEYS_FILE"
+    echo "API Keys written to $MEILI_API_KEYS_FILE"
+  else
+    echo "Failed to retrieve API keys."
+  fi
+else
+  echo "Key file already exists at $MEILI_API_KEYS_FILE. Skipping key retrieval."
+fi
+
+# Wait for the MeiliSearch process so the container doesn't exit
+wait $MEILI_PID

--- a/tests/docker/mongo/Dockerfile
+++ b/tests/docker/mongo/Dockerfile
@@ -1,0 +1,10 @@
+# This Dockerfile is needed due to enabling replica mode in docker requiring some extra steps 
+FROM mongo:8
+
+COPY mongod.docker.conf mongod.docker.conf
+COPY run-mongo.sh ./
+COPY enable-replica-set.js ./
+
+RUN chmod +x /run-mongo.sh
+
+CMD ./run-mongo.sh

--- a/tests/docker/mongo/README.md
+++ b/tests/docker/mongo/README.md
@@ -1,0 +1,1 @@
+Mongo needs some hand holding provided by this directory to properly enable replica sets with docker

--- a/tests/docker/mongo/enable-replica-set.js
+++ b/tests/docker/mongo/enable-replica-set.js
@@ -1,0 +1,18 @@
+try {
+    try {
+        assert(rs.status().ok)
+    } catch (error) {
+        if (error.name === 'MongoServerError' && error.codeName === 'NotYetInitialized') {
+            console.log('rs.status is not ok, but expected. running rs.initiate()')
+            rs.initiate()
+            assert(rs.status().ok)
+        } else {
+            throw error
+        }
+    }
+} catch (error) {
+    console.log('error with first startup')
+    console.log(error)
+    assert(error)
+}
+console.log('mongo is good')

--- a/tests/docker/mongo/mongod.docker.conf
+++ b/tests/docker/mongo/mongod.docker.conf
@@ -1,4 +1,4 @@
 replication:
   replSetName: rs0
 net:
-  bindIp: db-mongo
+  bindIp: 0.0.0.0

--- a/tests/docker/mongo/mongod.docker.conf
+++ b/tests/docker/mongo/mongod.docker.conf
@@ -1,0 +1,4 @@
+replication:
+  replSetName: rs0
+net:
+  bindIp: db-mongo

--- a/tests/docker/mongo/run-mongo.sh
+++ b/tests/docker/mongo/run-mongo.sh
@@ -4,12 +4,12 @@ set -e
 mongod --config /mongod.docker.conf > /var/log/yex.log 2>&1 &
 
 # Wait for MongoDB to be ready
-until mongosh --host db-mongo --eval "print(\"waited for connection\")"
+until mongosh --eval "print(\"waited for connection\")"
 do
     sleep 1
 done
 
-mongosh --host db-mongo --file /enable-replica-set.js
+mongosh --file /enable-replica-set.js
 
 # keep the container running
 tail -f /dev/null

--- a/tests/docker/mongo/run-mongo.sh
+++ b/tests/docker/mongo/run-mongo.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+mongod --config /mongod.docker.conf > /var/log/yex.log 2>&1 &
+
+# Wait for MongoDB to be ready
+until mongosh --host db-mongo --eval "print(\"waited for connection\")"
+do
+    sleep 1
+done
+
+mongosh --host db-mongo --file /enable-replica-set.js
+
+# keep the container running
+tail -f /dev/null

--- a/tests/docker/postgres/Dockerfile
+++ b/tests/docker/postgres/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:15
+
+# Install wal2json plugin
+RUN apt-get update && apt-get install -y \
+    postgresql-server-dev-15 \
+    build-essential \
+    git \
+    && git clone https://github.com/eulerto/wal2json.git /wal2json \
+    && cd /wal2json && make && make install \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /wal2json
+
+COPY postgresql.conf /etc/postgresql/

--- a/tests/docker/postgres/postgresql.conf
+++ b/tests/docker/postgres/postgresql.conf
@@ -1,0 +1,4 @@
+wal_level = logical
+shared_preload_libraries = 'pg_stat_statements,wal2json'
+listen_addresses = '*'
+port = 5432


### PR DESCRIPTION
Fixes #118 

This gets the bare minimum existing tests runnable via Docker. 
It is not the best testing setup --- lots of room for improvements --- just what I could get running quickly with minimal code changes. Happy to clean it up some, especially if given help/recommendations on how to handle more versions of databases.

Usage preview (full details in README):
```
docker compose up --build -d
docker exec -it meilisync-localdev-meilisync-1 poetry run pytest
```