### PR TITLE
migrate `Source` and `Progress` to pydantic v2 `model_config`

### DIFF
--- a/meilisync/settings.py
+++ b/meilisync/settings.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, ConfigDict
 from pydantic_settings import BaseSettings
 
 from meilisync.enums import ProgressType, SourceType
@@ -11,8 +11,7 @@ class Source(BaseModel):
     type: SourceType
     database: str
 
-    class Config:
-        extra = Extra.allow
+    model_config = ConfigDict(extra="allow")
 
 
 class MeiliSearch(BaseModel):
@@ -54,8 +53,7 @@ class Sync(BasePlugin):
 class Progress(BaseModel):
     type: ProgressType
 
-    class Config:
-        extra = Extra.allow
+    model_config = ConfigDict(extra="allow")
 
 
 class Sentry(BaseModel):


### PR DESCRIPTION
Fixes #128

## Summary

Replaces the deprecated pydantic v1 nested `class Config:` + `Extra.allow` in
`meilisync/settings.py` (`Source`, `Progress`) with the v2
`model_config = ConfigDict(extra="allow")` form.

Every import of `settings.py` under pydantic v2 currently emits 4
`PydanticDeprecatedSince20` warnings (2 per model: the `Extra` member access and the
class-based config). This removes all of them.

## Changes

- `meilisync/settings.py`: both nested `class Config:` blocks → `model_config`; drop the unused `Extra` import, add `ConfigDict`.

## Testing

- Verified with pydantic 2.13.4: importing the module emits zero warnings
  (before: 4 `DeprecationWarning`s).
- Semantics preserved: `extra="allow"` behaves identically to `extra = Extra.allow`.